### PR TITLE
[MOD] 커스텀 워터마크 수신 키 변경 #12

### DIFF
--- a/app/src/main/java/com/example/transparentkey_aos/EmbedFragment.kt
+++ b/app/src/main/java/com/example/transparentkey_aos/EmbedFragment.kt
@@ -52,8 +52,8 @@ class EmbedFragment : Fragment() {
         setFragmentResultListener("wmSelection") { key, bundle ->
             val selection = bundle.getInt("selection", -1)
             when (selection) {
+                // qr 선택한 경우 실행
                 1 -> {
-                    // qr 선택한 경우 실행
                     @Suppress("DEPRECATION")
                     setFragmentResultListener("qr_img") { key, bundle ->
                         val img: Bitmap? = bundle.getParcelable("qr_img")
@@ -80,12 +80,12 @@ class EmbedFragment : Fragment() {
 
                 }
 
+                // img
+                // 워터마크 이미지 수신
                 2 -> {
-                    // img
-                    // 워터마크 이미지 수신
                     @Suppress("DEPRECATION")
-                    setFragmentResultListener("wm_img2") { key, bundle ->
-                        val img: Bitmap? = bundle.getParcelable("wm_img2")
+                    setFragmentResultListener("wmimg_embed") { key, bundle ->
+                        val img: Bitmap? = bundle.getParcelable("wmimg_embed")
                         if (img != null) { // null이 아닐 때만 사용
                             wmImg = img
                             binding.ivWmImage.setImageBitmap(wmImg) // 이미지 iv에 배치
@@ -93,6 +93,7 @@ class EmbedFragment : Fragment() {
                             Toast.makeText(context, "워터마크 이미지를 불러오는데 실패했습니다.", Toast.LENGTH_SHORT).show()
                         }
                     }
+
                     // 워터마크 할 배경 이미지 수신
                     @Suppress("DEPRECATION")
                     setFragmentResultListener("selected_embed_img") { key, bundle ->
@@ -124,6 +125,9 @@ class EmbedFragment : Fragment() {
 
     }
 
+    /**
+     * Apply watermark
+     */
     private fun uploadImages(background_img: Bitmap, wm_img: Bitmap?) {
         if (!::wmImg.isInitialized) {
             Toast.makeText(context, "워터마크 이미지가 설정되지 않았습니다.", Toast.LENGTH_SHORT).show()
@@ -163,7 +167,7 @@ class EmbedFragment : Fragment() {
                         binding.btnSaveImg.isEnabled = true
                     }
                 } else {
-                    Toast.makeText(context, "Error", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, "Error : 워터마킹 실패", Toast.LENGTH_SHORT).show()
 
                 }
             }
@@ -176,7 +180,9 @@ class EmbedFragment : Fragment() {
         })
     }
 
-    // Save watermarked image
+    /**
+     * Save watermarked image
+     */
     fun saveImageToStorage(bitmap: Bitmap) {
         val appName = getString(R.string.app_name)  // 앱 이름 가져오기
         val filename = "watermarked_${System.currentTimeMillis()}.jpg"

--- a/app/src/main/java/com/example/transparentkey_aos/EmbedImageSelectFragment.kt
+++ b/app/src/main/java/com/example/transparentkey_aos/EmbedImageSelectFragment.kt
@@ -53,7 +53,7 @@ class EmbedImageSelectFragment : Fragment() {
 
                 // 다음 다이얼로그로 전환
                 setFragmentResult(REQUEST_KEY, bundleOf("wm_img" to selectedWatermark))
-                setFragmentResult("wm_img_2", bundleOf("wm_img_2" to selectedWatermark))
+                setFragmentResult("wmimg_embed", bundleOf("wmimg_embed" to selectedWatermark))
                 showImgDialog()
             } catch (e: Exception) {
                 Log.e("EmbedImageSelectFragment", "Image selection failed", e)

--- a/app/src/main/java/com/example/transparentkey_aos/EmbedWatermarkSelectFragment.kt
+++ b/app/src/main/java/com/example/transparentkey_aos/EmbedWatermarkSelectFragment.kt
@@ -43,9 +43,9 @@ class EmbedWatermarkSelectFragment : Fragment() {
             showDialog()
         }
         binding.btnImg.setOnClickListener {
-//            setFragmentResult("wmSelection", bundleOf("selection" to 2))
-//            replaceFragment(EmbedImageSelectFragment())
-            Toast.makeText(context, "개발 중입니다.", Toast.LENGTH_SHORT).show()
+            setFragmentResult("wmSelection", bundleOf("selection" to 2))
+            replaceFragment(EmbedImageSelectFragment())
+//            Toast.makeText(context, "개발 중입니다.", Toast.LENGTH_SHORT).show()
         }
     }
 


### PR DESCRIPTION
## 🚀관련 이슈

- #12 

## ✨작업 내용

- **이미지 워터마킹 구현**

-  `EmbedImageSelectFragment` —> `EmbedFragment`로  선택한 워터마크 이미지 정보를 전송할 때 키 변경함.


## 📸 스크린샷
<img width="250" alt="스크린샷 2024-05-20 오후 3 58 46" src="https://github.com/invisible-key-project/invisible-key-front/assets/90364562/83f3decc-0a34-4ec8-8c9d-bb587aef2679">

<img width="250" alt="스크린샷 2024-05-20 오후 1 26 32" src="https://github.com/invisible-key-project/invisible-key-front/assets/90364562/3f05cb78-b85c-49db-b501-9210037aa478">

<img width="250" alt="스크린샷 2024-05-20 오후 1 26 46" src="https://github.com/invisible-key-project/invisible-key-front/assets/90364562/c391a907-f4e4-41d9-8b38-f8705c6cd98b">

<img width="250" alt="스크린샷 2024-05-20 오후 1 27 00" src="https://github.com/invisible-key-project/invisible-key-front/assets/90364562/02fb2985-d768-4aa0-840e-7db309559cc1">
<img width="250" alt="스크린샷 2024-05-20 오후 1 29 04" src="https://github.com/invisible-key-project/invisible-key-front/assets/90364562/505740d1-623d-4b29-b94b-c47d3b97c77a">


## 📝참고 사항
